### PR TITLE
Require CVE ID in advisories, year portion of ID, grammar

### DIFF
--- a/CNA_Rules.md
+++ b/CNA_Rules.md
@@ -435,6 +435,8 @@ CNAs are constrained to assigning CVE IDs to Vulnerabilities within their Scope 
 
 4.2.20 To help minimize duplicate assignments, CNAs SHOULD consider coordinating with an appropriate Root or CNA-LR before assigning CVE IDs for Publicly Disclosed Vulnerabilities. See 4.2.1.2 for more specific guidance.
 
+4.2.21 CNAs SHOULD assign the year portion of a CVE ID based on the calendar year in which the vulnerability was first publicly disclosed.
+
 ### 4.3 Notification
 
 4.3.1 When a CNA becomes aware of a non-public Vulnerability report, CVE ID request, or CVE ID assignment that is only covered by the Scope Definition of a different CNA, the first CNA SHOULD either refer the reporter or requester to or attempt to notify the appropriate CNA.
@@ -486,7 +488,7 @@ This section specifies actions related to publishing and managing CVE Records.
 
 4.5.2 Publishing Vulnerability Information
 
-4.5.2.1 CNA MUST publish Vulnerability advisories or other information about Vulnerabilities for which the CNA has assigned CVE IDs and published CVE Records. Such information SHOULD meet the public references requirements in [5.3](#53-public-references) and MAY be used as a public reference (see 5.3.1.1).
+4.5.2.1 CNAs MUST publish Vulnerability advisories or other information about Vulnerabilities for which the CNA has assigned CVE IDs and published CVE Records. Such information SHOULD meet the public references requirements in [5.3](#53-public-references) and MAY be used as a public reference (see 5.3.1.1).
 
 4.5.2.2 Supplier CNAs MUST have at least one distribution point, such as a web site, where the CNA publishes Vulnerability advisories or other information about Vulnerabilities for which the CNA has assigned CVE IDs and published CVE Records. This Vulnerability information MUST reference appropriate CVE IDs.
 

--- a/CNA_Rules.md
+++ b/CNA_Rules.md
@@ -2,9 +2,9 @@
 
 | Status | Final |
 | ---: | :--- |
-| Version | 4.0.0 |
-| Approved | 2024-04-25 |
-| Effective | 2024-05-08 |
+| Version | 4.0.1 |
+| Approved | 2025-mm-dd |
+| Effective | 2025-mm-dd |
 
 ## Table of Contents
 
@@ -486,9 +486,9 @@ This section specifies actions related to publishing and managing CVE Records.
 
 4.5.2 Publishing Vulnerability Information
 
-4.5.2.1 CNA SHOULD publish Vulnerability advisories or other information about Vulnerabilities for which the CNA has assigned CVE IDs and published CVE Records. Such information SHOULD meet the public references requirements in [5.3](#53-public-references) and MAY be used as a public reference (see 5.3.1.1).
+4.5.2.1 CNA MUST publish Vulnerability advisories or other information about Vulnerabilities for which the CNA has assigned CVE IDs and published CVE Records. Such information SHOULD meet the public references requirements in [5.3](#53-public-references) and MAY be used as a public reference (see 5.3.1.1).
 
-4.5.2.2 Supplier CNAs MUST have at least one distribution point, such as a web site, where the CNA publishes Vulnerability advisories or other information about Vulnerabilities for which the CNA has assigned CVE IDs and published CVE Records. This Vulnerability information SHOULD reference appropriate CVE IDs.
+4.5.2.2 Supplier CNAs MUST have at least one distribution point, such as a web site, where the CNA publishes Vulnerability advisories or other information about Vulnerabilities for which the CNA has assigned CVE IDs and published CVE Records. This Vulnerability information MUST reference appropriate CVE IDs.
 
 4.5.2.3 The Vulnerability information described in 4.5.2.1 MUST generally support and MUST NOT contradict information published by the CNA in corresponding CVE Records.
 

--- a/CNA_Rules.md
+++ b/CNA_Rules.md
@@ -435,7 +435,7 @@ CNAs are constrained to assigning CVE IDs to Vulnerabilities within their Scope 
 
 4.2.20 To help minimize duplicate assignments, CNAs SHOULD consider coordinating with an appropriate Root or CNA-LR before assigning CVE IDs for Publicly Disclosed Vulnerabilities. See 4.2.1.2 for more specific guidance.
 
-4.2.21 CNAs SHOULD assign the year part of a CVE ID based on the calendar year in which the vulnerability was first publicly disclosed. CNAs MUST NOT, based on this rule, change CVE IDs that have already been Publicly Disclosed.
+4.2.21 CNAs SHOULD assign the year part of a CVE ID based on the calendar year in which the vulnerability was first Publicly Disclosed, the CVE Record was first published, or the CVE ID was reserved for the vulnerability in question. CNAs MUST NOT, based on this rule, change CVE IDs that have already been published. CNAs MAY assign CVE IDs in one calendar year and publish the corresponding CVE Record in the next calendar year.
 
 ### 4.3 Notification
 

--- a/CNA_Rules.md
+++ b/CNA_Rules.md
@@ -435,7 +435,7 @@ CNAs are constrained to assigning CVE IDs to Vulnerabilities within their Scope 
 
 4.2.20 To help minimize duplicate assignments, CNAs SHOULD consider coordinating with an appropriate Root or CNA-LR before assigning CVE IDs for Publicly Disclosed Vulnerabilities. See 4.2.1.2 for more specific guidance.
 
-4.2.21 CNAs SHOULD assign the year portion of a CVE ID based on the calendar year in which the vulnerability was first publicly disclosed.
+4.2.21 CNAs SHOULD assign the year part of a CVE ID based on the calendar year in which the vulnerability was first publicly disclosed. CNAs MUST NOT, based on this rule, change CVE IDs that have already been Publicly Disclosed.
 
 ### 4.3 Notification
 


### PR DESCRIPTION
The current rules allow a CNA to not publish an advisory about a CVE ID they assigned, and also an advisory is not required to cite the relevant CVE ID(s).