### PR TITLE
Add Existing Code of Conduct for CVE Program

### DIFF
--- a/Code_of_Conduct.md
+++ b/Code_of_Conduct.md
@@ -1,0 +1,44 @@
+# CVE Program Professional Code of Conduct
+
+In the interest of fostering an open and welcoming environment, [CVE Board](https://www.cve.org/ProgramOrganization/Board) members agree to make participation in the CVE Program, and directly related activities, a harassment-free experience for everyone involved with the program, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+All individuals participating in the program, regardless of role (Board member, [Secretariat](https://www.cve.org/ResourcesSupport/Glossary?activeTerm=glossarySecretariat), [Top-Level Root](https://www.cve.org/ResourcesSupport/Glossary?activeTerm=glossaryTLRoot), [Root](https://www.cve.org/ResourcesSupport/Glossary?activeTerm=glossaryRoot), [CNA of Last Resort](https://www.cve.org/ResourcesSupport/Glossary?activeTerm=glossaryCNALR), [CNA](https://www.cve.org/ResourcesSupport/Glossary?activeTerm=glossaryCNA), [Working Group](https://www.cve.org/ResourcesSupport/Glossary?activeTerm=glossaryWG) chair, Working Group member) are expected to adhere to the Professional Code of Conduct. The Code of Conduct also applies to any individual serving in a role on a temporary basis, due to the unavailability of the assigned/primary individual.
+
+## Professional Code of Conduct
+
+CVE Program participants are expected to:
+
+- Conduct program business in a professional, honest, cooperative, and fair manner at all times.
+- Make a good faith effort to fulfill their role to the best of their ability.
+- Respect the rights of all participants to fair treatment and equal opportunity, in an environment free of discrimination and harassment.
+- Comply with the [CVE Program Terms of Use](https://www.cve.org/Legal/TermsOfUse).
+- Comply with the [CNA Rules](https://www.cve.org/ResourcesSupport/AllResources/CNARules).
+- Protect CVE Program assets and resources from theft, damage, or misuse.
+- Respect, to the best of their knowledge, the customs and norms of the international community of participants.
+- Avoid conflicts of interest between their work/role on the program and their work/role in their organization.
+- Refrain from using their role on the program for personal gain.
+
+Examples of inappropriate conduct include:
+- Engaging in public or private harassment in program forums, meetings, emails or other communications and interactions.
+- Using sexualized language or imagery, or showing sexual attention or advances in program forums, meetings, emails or other communications and interactions.
+- Using insulting or derogatory language, verbally or in writing.
+- Expressing political, religious, or other culture-related opinions, verbally or in writing, that the majority of the Board finds offensive.
+- Publishing others’ private information, such as a physical or electronic address, without explicit permission from that person(s).
+- Participating in actions and efforts meant to purposely harm the CVE Program, e.g., violating the [CVE Program Terms of Use](https://www.cve.org/Legal/TermsOfUse), using CVE Intellectual Property or trademark without authorization.
+- Other conduct that would reasonably be considered inappropriate in a professional setting.
+- The Secretariat and the Board are responsible for development of the Code of Conduct, and updates or revisions.
+
+## Complaints
+
+Any program participant may report a Code of Conduct complaint. The reporting participant must have directly observed, heard or read something thought to be a violation, and be able to provide details about the incident.
+
+Complaints must be reported to the Secretariat (cve-prog-secretariat@mitre.org). The Secretariat must maintain the confidentiality of the reporter of an incident. The Secretariat will investigate complaints that provide enough detail to proceed. The investigation will result in a finding of either “no further action” or “verified.”
+
+- In cases where the investigation finds that no further action is warranted, the Secretariat will respond back to the reporter with the finding result and rationale for the decision.
+- In cases where the investigation finds verified evidence that the code of conduct was violated, the Secretariat will respond back to the reporter about the decision to proceed, and the following actions will commence:
+  - The Secretariat will notify the Board about the complaint.
+  - The Secretariat will send a message, on behalf of the Board, to the offending party, calling out the unacceptable behavior. The message will explain both the corrective action required and the consequence of failing to correct the inappropriate behavior. It will also explain that repeated behavior of this type may result in removal from the program.
+    - The organization affiliated with the party will also be sent this message, if the complaint is related to an action taken as an agent of that organization.
+- When the complaint is closed, the Secretariat will respond back to the reporter explaining the actions taken.
+
+If the individual in question has repeated complaints, the Secretariat will bring this fact to the Board’s attention. The Board will then convene an Executive meeting (MITRE Board representative must attend) to review and discuss next steps. The Board and the Secretariat will decide on and execute the agreed-to next steps on a case-by-case basis; this may include removal of the individual and/or the individual’s organization from the CVE Program.

--- a/Code_of_Conduct.md
+++ b/Code_of_Conduct.md
@@ -19,6 +19,7 @@ CVE Program participants are expected to:
 - Refrain from using their role on the program for personal gain.
 
 Examples of inappropriate conduct include:
+
 - Engaging in public or private harassment in program forums, meetings, emails or other communications and interactions.
 - Using sexualized language or imagery, or showing sexual attention or advances in program forums, meetings, emails or other communications and interactions.
 - Using insulting or derogatory language, verbally or in writing.
@@ -26,13 +27,14 @@ Examples of inappropriate conduct include:
 - Publishing others’ private information, such as a physical or electronic address, without explicit permission from that person(s).
 - Participating in actions and efforts meant to purposely harm the CVE Program, e.g., violating the [CVE Program Terms of Use](https://www.cve.org/Legal/TermsOfUse), using CVE Intellectual Property or trademark without authorization.
 - Other conduct that would reasonably be considered inappropriate in a professional setting.
-- The Secretariat and the Board are responsible for development of the Code of Conduct, and updates or revisions.
+
+The Secretariat and the Board are responsible for development of the Code of Conduct, and updates or revisions.
 
 ## Complaints
 
 Any program participant may report a Code of Conduct complaint. The reporting participant must have directly observed, heard or read something thought to be a violation, and be able to provide details about the incident.
 
-Complaints must be reported to the Secretariat (cve-prog-secretariat@mitre.org). The Secretariat must maintain the confidentiality of the reporter of an incident. The Secretariat will investigate complaints that provide enough detail to proceed. The investigation will result in a finding of either “no further action” or “verified.”
+Complaints must be reported to [the Secretariat](cve-prog-secretariat@mitre.org). The Secretariat must maintain the confidentiality of the reporter of an incident. The Secretariat will investigate complaints that provide enough detail to proceed. The investigation will result in a finding of either “no further action” or “verified.”
 
 - In cases where the investigation finds that no further action is warranted, the Secretariat will respond back to the reporter with the finding result and rationale for the decision.
 - In cases where the investigation finds verified evidence that the code of conduct was violated, the Secretariat will respond back to the reporter about the decision to proceed, and the following actions will commence:


### PR DESCRIPTION
Adds the existing Professional Code of Conduct as a Markdown document. It outlines expected behaviors and procedures for reporting violations for CVE Program participants.

Closes https://github.com/CVEProject/cve-documents/issues/32